### PR TITLE
replace rstrip for replace

### DIFF
--- a/nettools.py
+++ b/nettools.py
@@ -72,7 +72,7 @@ class ThreadedRBLLookup(threading.Thread):
                 self.log.debug("Queue empty, shutting down")
                 return
 
-            reverse = IPy.IP(self.addr).reverseName().replace(".in-addr.arpa.",'',1).replace(".ip6.arpa.",'',1)
+            reverse = IPy.IP(self.addr).reverseName().replace(".in-addr.arpa.", "").replace(".ip6.arpa.", "")
             lookup_addr = "%s.%s." % (reverse, rbl)
             try:
                 self.log.debug("Checking %s for %s (query addr: %s)", rbl, reverse, lookup_addr)

--- a/nettools.py
+++ b/nettools.py
@@ -72,7 +72,7 @@ class ThreadedRBLLookup(threading.Thread):
                 self.log.debug("Queue empty, shutting down")
                 return
 
-            reverse = IPy.IP(self.addr).reverseName().rstrip("in-addr.arpa").rstrip("ip6.arpa")
+            reverse = IPy.IP(self.addr).reverseName().replace(".in-addr.arpa.",'',1).replace(".ip6.arpa.",'',1)
             lookup_addr = "%s.%s." % (reverse, rbl)
             try:
                 self.log.debug("Checking %s for %s (query addr: %s)", rbl, reverse, lookup_addr)


### PR DESCRIPTION
rstrip removes all caracters that are given from a string so the ip `196.21.33.146` will return as `146.33.21.19`  see down here for an example

```
>>> IPy.IP("196.21.33.146").reverseName().rstrip('in-addr.arpa').rstrip('ip6.arpa')
'146.33.21.19'
```
now it will only remove the arp strings